### PR TITLE
Check for GitHub actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Currently, `actions/checkout` is out-of-date, and uses a node version that has hit end-of-life. Dependabot should check new versions automatically, so that this won't be an issue.